### PR TITLE
Add info on kustomize v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ This repository contains a [deploy](deploy) folder which contains all of the man
 
 If you would like to apply your own customizations, reference the `deploy` folder and the version in your `kustomization.yaml`.
 
+#### Kustomize v2 
+(version used in `kubectl apply -k .`)
+
+```yaml
+bases:
+- git::https://github.com/plexsystems/sandbox-operator.git//deploy?ref=v0.8.0
+```
+
+#### Kustomize v3
+Latest version of Kustomize if installed as a standalone.  Also version embedded in flux.
+
 ```yaml
 resources:
 - git::https://github.com/plexsystems/sandbox-operator.git//deploy?ref=v0.8.0


### PR DESCRIPTION
Minor update to readme to illustrate usage for Kustomize v2 users.  Mostly concerned about users that are heavily leveraging the kustomize version build into kubectl.  Looking at https://github.com/kubernetes/kubectl/blob/release-1.18/go.mod I think even the 1.18 release of kubectl is still using Kustomize 2.