### PR TITLE
Update final container to alpine 3.11.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 RUN GOOS=linux GOARCH=amd64 go build -o sandbox-operator main.go
 
-FROM alpine:3.11.2
+FROM alpine:3.11.6
 ENV OPERATOR=/usr/local/bin/sandbox-operator \
     USER_UID=1001 \
     USER_NAME=sandbox-operator


### PR DESCRIPTION
Addressing CVE-2020-1967.  [Alpine 3.11.6 includes the fix](https://alpinelinux.org/posts/Alpine-3.11.6-released.html).